### PR TITLE
x64環境でmp3infp_cplが起動しない・クラッシュする

### DIFF
--- a/src/GlobalCommand.cpp
+++ b/src/GlobalCommand.cpp
@@ -110,7 +110,7 @@ BOOL GetDLLVersion(IN LPTSTR szDLLFileName,
 //•¶––‚ªYen‚Ì‚Æ‚«TRUE
 BOOL IsTailYenSign(LPCTSTR szStr)
 {
-	LPTSTR yen = _tcsrchr(szStr,_T('\\'));
+	LPCTSTR yen = _tcsrchr(szStr,_T('\\'));
 	if(yen && (&szStr[lstrlen(szStr)-1] == yen))
 	{
 		return TRUE;

--- a/src/mp3infp_cpl/mp3infp_cpl.cpp
+++ b/src/mp3infp_cpl/mp3infp_cpl.cpp
@@ -83,7 +83,7 @@ CMp3infp_cplApp::~CMp3infp_cplApp()
 {
 }
 
-extern "C" LONG __stdcall CMp3infp_cplApp::CPlApplet(HWND hWnd,UINT uMsg,LONG lParam1,LONG lParam2)
+extern "C" LONG __stdcall CMp3infp_cplApp::CPlApplet(HWND hWnd, UINT uMsg, LPARAM lParam1,LPARAM lParam2)
 {
 	AFX_MANAGE_STATE(AfxGetStaticModuleState()); 
 
@@ -105,7 +105,7 @@ extern "C" LONG __stdcall CMp3infp_cplApp::CPlApplet(HWND hWnd,UINT uMsg,LONG lP
 
 	switch(uMsg){
 	case CPL_DBLCLK:
-		return OnDblclk(hWnd,lParam1,lParam2);
+		return OnDblclk(hWnd,(UINT)lParam1,(LONG_PTR)lParam2);
 
 	case CPL_EXIT:
 		return OnExit();
@@ -117,16 +117,16 @@ extern "C" LONG __stdcall CMp3infp_cplApp::CPlApplet(HWND hWnd,UINT uMsg,LONG lP
 		return OnInit();
 
 	case CPL_INQUIRE:
-		return OnInquire(lParam1,(CPLINFO *)lParam2);
+		return OnInquire((UINT)lParam1, (CPLINFO *)lParam2);
 
 	case CPL_NEWINQUIRE:
-		return OnNewInquire(lParam1,(NEWCPLINFO *)lParam2);
+		return OnNewInquire((UINT)lParam1, (NEWCPLINFO *)lParam2);
 
 	case CPL_STOP:
-		return OnStop(lParam1,lParam2);
+		return OnStop((UINT)lParam1, (LONG_PTR)lParam2);
 
 	case CPL_STARTWPARMS:
-		OnDblclk(hWnd, lParam1, lParam2);
+		OnDblclk(hWnd, (UINT)lParam1, (LONG_PTR)lParam2);
 		return TRUE;
 
 	default:
@@ -167,7 +167,7 @@ LONG CMp3infp_cplApp::OnInquire(UINT uAppNum,CPLINFO* pInfo)
 	return 0;
 }
 
-LONG CMp3infp_cplApp::OnDblclk(HWND hWnd,UINT uAppNum,LONG lData)
+LONG CMp3infp_cplApp::OnDblclk(HWND hWnd,UINT uAppNum,LONG_PTR lData)
 {
 #ifdef _DEBUG
 	OutputDebugString("CMp3infp_cplApp::OnDblclk()\n");
@@ -227,7 +227,7 @@ LONG CMp3infp_cplApp::OnInit()
 	return 1; // OK
 }
 
-LONG CMp3infp_cplApp::OnStop(UINT uAppNum,LONG lData) 
+LONG CMp3infp_cplApp::OnStop(UINT uAppNum,LONG_PTR lData) 
 {
 #ifdef _DEBUG
 	OutputDebugString("CMp3infp_cplApp::OnStop()\n");

--- a/src/mp3infp_cpl/mp3infp_cpl.h
+++ b/src/mp3infp_cpl/mp3infp_cpl.h
@@ -26,15 +26,15 @@ class CMp3infp_cplApp : public CWinApp
 public:
 	CMp3infp_cplApp();
 	virtual ~CMp3infp_cplApp();
-	static	LONG __stdcall CPlApplet(HWND hWnd,UINT uMsg,LONG lParam1,LONG lParam2);
+	static	LONG __stdcall CPlApplet(HWND hWnd,UINT uMsg,LPARAM lParam1,LPARAM lParam2);
 
-	static	LONG	OnDblclk(HWND hWnd,UINT uAppNum,LONG lData);
+	static	LONG	OnDblclk(HWND hWnd,UINT uAppNum,LONG_PTR lData);
 	static	LONG	OnExit();
 	static	LONG	OnGetCount();
 	static	LONG	OnInit();
 	static	LONG	OnInquire(UINT uAppNum,CPLINFO* pInfo);
 	static	LONG	OnNewInquire(UINT uAppNum,NEWCPLINFO* pInfo);
-	static	LONG	OnStop(UINT uAppNum,LONG lData);
+	static	LONG	OnStop(UINT uAppNum,LONG_PTR lData);
 	static	LONG LoadLanguage();
 
 	static	CMp3infp_cplApp* m_pThis;


### PR DESCRIPTION
コールバック関数の定義でLPARAMの代わりにLONGが使われていたために、アクセス違反で落ちていたようです。
またこちらは致命的ではありませんが、周辺で使われている型も確認して、キャストや定義の変更を行いました。
